### PR TITLE
chore: Switch to commonjs module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "files": [
     "dist"
   ],
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "bin": {
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "start": "node --experimental-modules --es-module-specifier-resolution=node dist/bin/index.js"
+    "start": "node dist/bin/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,19 +1,18 @@
 #!/usr/bin/env node --experimental-modules --es-module-specifier-resolution=node --no-warnings
-import { Contrast } from "../lib/index";
-import { existsSync, readFileSync } from "fs";
-import { inspect } from "util";
-import url from "url";
-const { URL } = url;
+import { Contrast } from '../lib/index';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { inspect } from 'util';
 
 const foreground: string = process.argv.slice(2)[0];
 const background: string = process.argv.slice(2)[1];
 
 function getVersion(): string | void {
-  const path: url.URL = new URL("../../package.json", import.meta.url);
+  const path = resolve(process.cwd(), 'package.json');
   if (!existsSync(path)) {
     return;
   }
-  const raw: string = readFileSync(path, { encoding: "utf-8" });
+  const raw: string = readFileSync(path, { encoding: 'utf-8' });
   if (!raw) {
     return;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
+    "target": "es5",
+    "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Hi, i suggest to switch to commonjs as module resolution. Currently it is necessary to reconfigure jest, webpack and other build processes to transpile the contrast library aswell. This should not be necessary, a npm package should be shipped in a way that it is not necessary to transpile it again, this should be do before the publishing.
I hope my change is fine for you.