### PR TITLE
chore: Release v7.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2019 Clay Miller
+Copyright (c) 2017-2021 Clay Miller
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smockle/contrast",
-  "version": "6.0.132",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@smockle/contrast",
-      "version": "6.0.128",
+      "version": "6.0.132",
       "license": "MIT",
       "bin": {
         "contrast": "dist/bin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smockle/contrast",
-  "version": "6.0.132",
+  "version": "7.0.0",
   "description": "Analyse luminosity contrast ratio",
   "files": [
     "dist"
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "start": "node --experimental-modules --es-module-specifier-resolution=node dist/bin/index.js"
+    "start": "node --experimental-specifier-resolution=node dist/bin/index.js"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^4.1.3"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 14.0.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-modules --es-module-specifier-resolution=node --no-warnings
+#!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
 import { Contrast } from "../lib/index";
 import { existsSync, readFileSync } from "fs";
 import { inspect } from "util";


### PR DESCRIPTION
* The `es-module-specifier-resolution` flag was [renamed](https://github.com/nodejs/node/issues/30520#issuecomment-588288220) to [`experimental-specifier-resolution`](https://nodejs.org/api/esm.html#esm_customizing_esm_specifier_resolution_algorithm)
* The `experimental-modules` flag is [no longer necessary](https://nodejs.org/uk/blog/release/v14.0.0/#ecmascript-modules-experimental-warning-removal) in Node.js 14, the [Active LTS](https://nodejs.org/en/about/releases/)