### PR TITLE
fix: Fix imports during runs and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "start": "node --experimental-specifier-resolution=node dist/bin/index.js"
+    "test": "node node_modules/jest/bin/jest.js",
+    "start": "node dist/bin/index.js"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^4.1.3"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 18.0.0"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",
@@ -51,6 +51,9 @@
       "ts-jest": {
         "useESM": true
       }
+    },
+    "moduleNameMapper": {
+      "^(\\.\\.?\\/.+)\\.jsx?$": "$1"
     }
   }
 }

--- a/src/__tests__/contrast.spec.ts
+++ b/src/__tests__/contrast.spec.ts
@@ -1,5 +1,5 @@
-import { Contrast } from "../lib/index";
-import { THRESHOLD } from "./util";
+import { Contrast } from "../lib/index.js";
+import { THRESHOLD } from "./util.js";
 import { inspect } from "util";
 
 describe("Contrast", () => {

--- a/src/__tests__/eightbit.spec.ts
+++ b/src/__tests__/eightbit.spec.ts
@@ -1,5 +1,5 @@
-import { EightBit } from "../lib/index";
-import { THRESHOLD } from "./util";
+import { EightBit } from "../lib/index.js";
+import { THRESHOLD } from "./util.js";
 import { inspect } from "util";
 
 describe("EightBit", () => {

--- a/src/__tests__/eightbitcolor.spec.ts
+++ b/src/__tests__/eightbitcolor.spec.ts
@@ -1,5 +1,5 @@
-import { EightBit, EightBitColor } from "../lib/index";
-import { THRESHOLD } from "./util";
+import { EightBit, EightBitColor } from "../lib/index.js";
+import { THRESHOLD } from "./util.js";
 import { inspect } from "util";
 
 describe("EightBitColor", () => {
@@ -19,7 +19,7 @@ describe("EightBitColor", () => {
     expect(new EightBitColor(0, 128, 255).valueOf()).toEqual({
       R: 0,
       G: 128,
-      B: 255
+      B: 255,
     });
   });
   test("inspect", () => {

--- a/src/__tests__/hex.spec.ts
+++ b/src/__tests__/hex.spec.ts
@@ -1,4 +1,4 @@
-import { Hex } from "../lib/index";
+import { Hex } from "../lib/index.js";
 import { inspect } from "util";
 
 describe("Hex", () => {

--- a/src/__tests__/hexcolor.spec.ts
+++ b/src/__tests__/hexcolor.spec.ts
@@ -1,4 +1,4 @@
-import { HexColor } from "../lib/index";
+import { HexColor } from "../lib/index.js";
 import { inspect } from "util";
 
 describe("HexColor", () => {
@@ -38,14 +38,14 @@ describe("HexColor", () => {
     expect(new HexColor("#0080FF").toEightBitColor().valueOf()).toEqual({
       R: 0,
       G: 128,
-      B: 255
+      B: 255,
     });
   });
   test("toEightBitColor", () => {
     expect(new HexColor(null).toEightBitColor().valueOf()).toEqual({
       R: 0,
       G: 0,
-      B: 0
+      B: 0,
     });
   });
 });

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,5 +1,5 @@
-#!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
-import { Contrast } from "../lib/index";
+#!/usr/bin/env node
+import { Contrast } from "../lib/index.js";
 import { existsSync, readFileSync } from "fs";
 import { inspect } from "util";
 import url from "url";

--- a/src/lib/contrast.ts
+++ b/src/lib/contrast.ts
@@ -1,4 +1,4 @@
-import { HexColor } from "./hexcolor";
+import { HexColor } from "./hexcolor.js";
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
 export class Contrast {

--- a/src/lib/eightbit.ts
+++ b/src/lib/eightbit.ts
@@ -1,4 +1,4 @@
-import { Hex } from "./hex";
+import { Hex } from "./hex.js";
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
 export class EightBit implements EightBit {

--- a/src/lib/eightbitcolor.ts
+++ b/src/lib/eightbitcolor.ts
@@ -1,5 +1,5 @@
-import { EightBit } from "./eightbit";
-import { HexColor } from "./hexcolor";
+import { EightBit } from "./eightbit.js";
+import { HexColor } from "./hexcolor.js";
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
 export class EightBitColor {

--- a/src/lib/hex.ts
+++ b/src/lib/hex.ts
@@ -1,4 +1,4 @@
-import { EightBit } from "./eightbit";
+import { EightBit } from "./eightbit.js";
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
 /**
@@ -24,13 +24,7 @@ export class Hex {
 
   constructor(value?: string | null) {
     this.value = value
-      ? padStart(
-          String(value)
-            .replace("#", "")
-            .toUpperCase(),
-          2,
-          "0"
-        )
+      ? padStart(String(value).replace("#", "").toUpperCase(), 2, "0")
       : null;
   }
   /** Returns the current value, e.g. "FF". */

--- a/src/lib/hexcolor.ts
+++ b/src/lib/hexcolor.ts
@@ -1,5 +1,5 @@
-import { Hex } from "./hex";
-import { EightBitColor } from "./eightbitcolor";
+import { Hex } from "./hex.js";
+import { EightBitColor } from "./eightbitcolor.js";
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
 export class HexColor {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,7 @@
-import { Contrast } from "./contrast";
-import { EightBit } from "./eightbit";
-import { EightBitColor } from "./eightbitcolor";
-import { Hex } from "./hex";
-import { HexColor } from "./hexcolor";
+import { Contrast } from "./contrast.js";
+import { EightBit } from "./eightbit.js";
+import { EightBitColor } from "./eightbitcolor.js";
+import { Hex } from "./hex.js";
+import { HexColor } from "./hexcolor.js";
 
 export { Contrast, EightBit, EightBitColor, Hex, HexColor };


### PR DESCRIPTION
`"type": "module"` in `package.json` necessitates including the `.js` file extension in file `import` statements. Details in [TypeScript docs: `type` in `package.json`](https://www.typescriptlang.org/docs/handbook/esm-node.html#type-in-packagejson-and-new-extensions).

Then, to fix `npm test`, I added the `moduleNameMapper` from https://github.com/kulshekhar/ts-jest/issues/1057#issuecomment-1482644543 (fixing the quotes).